### PR TITLE
Enhanced CLI Output with Colors and Server Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ For use with [kibitz](https://github.com/nick1udwig/kibitz).
 
 ```bash
 # Example using fetch
-uvx --from . ws-mcp --command "uvx mcp-server-fetch" --port 3002
+uvx ws-mcp --command "uvx mcp-server-fetch" --port 3002
 
 # Example using wcgw
 ## On macOS
-uvx --from . ws-mcp --command "uvx --from wcgw@latest --python 3.12 wcgw_mcp" --port 3001
+uvx ws-mcp --command "uvx --from wcgw@latest --python 3.12 wcgw_mcp" --port 3001
 
 ## On Linux (or if you have issues on macOS with wcgw)
 cd /tmp

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ For use with [kibitz](https://github.com/nick1udwig/kibitz).
 
 ```bash
 # Example using fetch
-uvx ws-mcp --command "uvx mcp-server-fetch" --port 3002
+uvx --from . ws-mcp --command "uvx mcp-server-fetch" --port 3002
 
 # Example using wcgw
 ## On macOS
-uvx ws-mcp --command "uvx --from wcgw@latest --python 3.12 wcgw_mcp" --port 3001
+uvx --from . ws-mcp --command "uvx --from wcgw@latest --python 3.12 wcgw_mcp" --port 3001
 
 ## On Linux (or if you have issues on macOS with wcgw)
 cd /tmp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     "jsonschema>=4.23.0",
     "websockets>=14.1",
+    "colorama>=0.4.6",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ws-mcp"
-version = "0.1.6"
+version = "0.1.7"
 description = "Wrap MCP servers with a WebSocket."
 readme = "README.md"
 authors = [{ name = "nick1udwig", email = "hosted-fornet@protonmail.com" }]


### PR DESCRIPTION
# Enhanced CLI Output with Colors and Server Names

Improves the CLI output of ws-mcp with more informative and visually appealing status messages.

## Changes

- Added colors and emojis to make server status more visually distinct
- Show server names from configuration in logs
- Added clear startup sequence:
  1. Initial "Starting X servers" message
  2. Individual success messages for each server
  3. Summary showing all started servers
  4. Final WebSocket URL

## Example Output

```
🚀 Starting 3 MCP servers...
✅ Started MCP server 'wcgw' [command: uvx --refresh --from wcgw@latest --python 3.12 wcgw_mcp]
✅ Started MCP server 'fetch' [command: uvx --refresh mcp-server-fetch]
✅ Started MCP server 'brave-search' [command: npx -y @modelcontextprotocol/server-brave-search]

✨ 3/3 MCP servers started successfully:
  • wcgw
  • fetch
  • brave-search

🔗 Multi-MCP bridge running on ws://localhost:3001
```

## Technical Details

- Added colorama dependency for cross-platform color support
- Modified server initialization to preserve configuration names
- Switched status messages from logging to print for better formatting control
- Maintained all existing error logging behavior

## Testing

Can be tested by running:
```bash
uvx --from . ws-mcp --env-file .env --config config.json --port 3001
```
